### PR TITLE
mkdocs for ec documentation

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,60 @@
+# Based on: https://github.com/multirepo-docs/root-docs:
+
+name: mkdocs
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - dev_docs
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs
+      - run: pip install mkdocs-material
+      - run: pip install mkdocs-mermaid2-plugin
+#      - run: pip install mkdocs-schema-reader
+      - run: pip install mkdocs-multirepo-plugin
+      - run: pip install mkdocs-literate-nav
+      - run: pip install mkdocs-jupyter
+      - run: pip install mkdocs-callouts
+      - name: Checkout
+        uses: actions/checkout@v3
+## no cleaup needed
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          repository: earthcube/geocodes
+#          path: docs/geocodes
+#      - run: cd docs/geocodes && rm -rf '!(docs)' && cd ..
+#
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          repository: earthcube/GeoCODES-Metadata
+#          path: docs/GeoCODES-Metadata
+#      - run: cd docs/GeoCODES-Metadata && rm -rf archive && cd ..
+##      - run: cd docs/GeoCODES-Metadata && rm -rf '!(docs)' && cd ..
+#
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          repository: gleanerio/gleaner
+#          path: docs/gleaner
+#      - run: cd docs/gleaner && rm -rf '!(docs)' && cd ..
+#
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          repository: gleanerio/nabu
+#          path: docs/nabu
+#      - run: cd docs/nabu && rm -rf '!(docs)' && cd ..
+
+
+ #     - run: cd docs/ && mkdocs gh-deploy --force --clean --verbose
+      - run:  mkdocs gh-deploy --force --clean --verbose
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,40 @@
+site_name: Gleaner IO Scheduler
+#theme: 'material'
+#theme: 'mkdocs'
+theme:
+  name: material
+#  name: 'readthedocs'
+  features:
+    #    - content.code.copy
+    - navigation.sections
+markdown_extensions:
+  - toc:
+      permalink: 
+  - attr_list
+  - def_list
+  - tables
+  - pymdownx.highlight:
+      use_pygments: false
+  - admonition
+  - pymdownx.snippets
+  - pymdownx.details
+  - pymdownx.superfences
+
+plugins:
+  - search
+# literate_nav must load after multirepo for the features to be available.
+  - multirepo:
+      # (optional) tells multirepo to cleanup the temporary directory after site is built.
+      cleanup: true
+  -  mermaid2
+  - literate-nav
+  -  mkdocs-jupyter
+  - callouts
+  # get a NoneType error, even when trying to generate in Geocodes-Metadata
+#  - schema_reader:
+#      include:
+#        - "./docs/GeoCODES-Metadata/schemas/"
+nav:
+  - Gleaner IO Scheduler:
+    - Dagster: README.md
+


### PR DESCRIPTION
add a mkdocs for use by the [earthcube documentation](https://github.com/earthcube/geocodes_documentation) 

found at: [ingest-orchestration](https://earthcube.github.io/geocodes_documentation/developers/ingest-orchestration/)